### PR TITLE
Configure OAuth2 to use Jason instead of Poison

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,8 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env()}.exs"
+
+config :oauth2,
+  serializers: %{
+    "application/json" => Jason
+  }


### PR DESCRIPTION
In https://github.com/StuartApp/stuart-client-elixir/pull/2 we replaced Poison by Jason, but we forgot to configure OAuth2 to use it.

We didn't notice because OAuth2 doesn't declare Poison as a dependency.