### PR TITLE
Take version for User-Agent from Application.spec

### DIFF
--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -37,7 +37,7 @@ defmodule StuartClientElixir.HttpClient do
   defp default_headers(access_token) do
     [
       Authorization: "Bearer #{access_token}",
-      "User-Agent": "stuart-client-elixir/#{StuartClientElixir.MixProject.version()}",
+      "User-Agent": "stuart-client-elixir/#{Mix.Project.config()[:version]}",
       "Content-Type": "application/json"
     ]
   end

--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -37,7 +37,7 @@ defmodule StuartClientElixir.HttpClient do
   defp default_headers(access_token) do
     [
       Authorization: "Bearer #{access_token}",
-      "User-Agent": "stuart-client-elixir/#{Mix.Project.config()[:version]}",
+      "User-Agent": "stuart-client-elixir/#{Application.spec(:stuart_client_elixir, :vsn)}",
       "Content-Type": "application/json"
     ]
   end

--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -37,7 +37,7 @@ defmodule StuartClientElixir.HttpClient do
   defp default_headers(access_token) do
     [
       Authorization: "Bearer #{access_token}",
-      "User-Agent": "stuart-client-elixir/#{Mix.Project.config()[:version]}",
+      "User-Agent": "stuart-client-elixir/#{StuartClientElixir.MixProject.version()}",
       "Content-Type": "application/json"
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,6 @@
 defmodule StuartClientElixir.MixProject do
   use Mix.Project
 
-  def version, do: "1.0.0"
-
   def project do
     [
       app: :stuart_client_elixir,
@@ -13,7 +11,7 @@ defmodule StuartClientElixir.MixProject do
           "GitHub" => "https://github.com/StuartApp/stuart-client-elixir"
         }
       },
-      version: version(),
+      version: "1.0.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule StuartClientElixir.MixProject do
   use Mix.Project
 
+  def version, do: "1.0.0"
+
   def project do
     [
       app: :stuart_client_elixir,
@@ -11,7 +13,7 @@ defmodule StuartClientElixir.MixProject do
           "GitHub" => "https://github.com/StuartApp/stuart-client-elixir"
         }
       },
-      version: "1.0.0",
+      version: version(),
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Taking the version from `Mix.Project` fails when working with released applications, where `Mix` is not available.

This PR changes it to take the version from `Application.spec` instead.