### PR TITLE
Return the same response format for OAuth errors.

### DIFF
--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -16,6 +16,8 @@ defmodule StuartClientElixir.HttpClient do
          headers <- default_headers(access_token) do
       HTTPoison.get(url, headers)
       |> to_api_response()
+    else
+      {:error, %OAuth2.Response{}} = oauth_error -> to_api_response(oauth_error)
     end
   end
 
@@ -25,6 +27,8 @@ defmodule StuartClientElixir.HttpClient do
          headers <- default_headers(access_token) do
       HTTPoison.post(url, body, headers)
       |> to_api_response()
+    else
+      {:error, %OAuth2.Response{}} = oauth_error -> to_api_response(oauth_error)
     end
   end
 
@@ -44,5 +48,9 @@ defmodule StuartClientElixir.HttpClient do
 
   defp to_api_response({:ok, %HTTPoison.Response{status_code: status_code, body: body}}) do
     %{status_code: status_code, body: Jason.decode!(body)}
+  end
+
+  defp to_api_response({:error, %OAuth2.Response{status_code: status_code, body: body}}) do
+    %{status_code: status_code, body: body}
   end
 end

--- a/test/stuart_client_elixir/http_client_test.exs
+++ b/test/stuart_client_elixir/http_client_test.exs
@@ -4,12 +4,22 @@ defmodule StuartClientElixirTest.HttpClientTest do
   import Mock
   alias StuartClientElixir.{Authenticator, HttpClient, Environment, Credentials}
 
+  @good_credentials %Credentials{
+    client_id: "good-id",
+    client_secret: "good-secret"
+  }
+
+  @bad_credentials %Credentials{
+    client_id: "bad-id",
+    client_secret: "bad-secret"
+  }
+
   setup_with_mocks([
     {
       Authenticator,
       [],
       [
-        access_token: fn _environment, _credentials -> {:ok, "sample-access-token"} end
+        access_token: fn _environment, credentials -> authenticator_response(credentials) end
       ]
     },
     {
@@ -17,10 +27,12 @@ defmodule StuartClientElixirTest.HttpClientTest do
       [],
       [
         get: fn _, _ ->
-          {:ok, %HTTPoison.Response{status_code: 201, body: Jason.encode!(%{sample: "response"})}}
+          {:ok,
+           %HTTPoison.Response{status_code: 201, body: Jason.encode!(%{sample: "get response"})}}
         end,
         post: fn _, _, _ ->
-          {:ok, %HTTPoison.Response{status_code: 201, body: Jason.encode!(%{sample: "response"})}}
+          {:ok,
+           %HTTPoison.Response{status_code: 201, body: Jason.encode!(%{sample: "post response"})}}
         end
       ]
     }
@@ -30,13 +42,10 @@ defmodule StuartClientElixirTest.HttpClientTest do
 
   describe "get" do
     test "calls HTTPoison with correct parameters" do
-      # given
-      HttpClient.get("/sample-endpoint", %{
-        environment: Environment.sandbox(),
-        credentials: sample_credentials()
-      })
+      expected_response = %{body: %{"sample" => "get response"}, status_code: 201}
 
-      # then
+      assert HttpClient.get("/sample-endpoint", config()) == expected_response
+
       assert called(
                HTTPoison.get(
                  "https://sandbox-api.stuart.com/sample-endpoint",
@@ -44,14 +53,21 @@ defmodule StuartClientElixirTest.HttpClientTest do
                )
              )
     end
+
+    test "returns explicit error when authentication fails" do
+      expected_response = %{body: %{"error" => "Bad credentials"}, status_code: 401}
+
+      assert HttpClient.get("/sample-endpoint", config(@bad_credentials)) == expected_response
+    end
   end
 
   describe "post" do
     test "calls HTTPoison with correct parameters" do
-      # when
-      HttpClient.post("/sample-endpoint", sample_request_body(), config())
+      expected_response = %{body: %{"sample" => "post response"}, status_code: 201}
 
-      # then
+      assert HttpClient.post("/sample-endpoint", sample_request_body(), config()) ==
+               expected_response
+
       assert called(
                HTTPoison.post(
                  "https://sandbox-api.stuart.com/sample-endpoint",
@@ -60,17 +76,25 @@ defmodule StuartClientElixirTest.HttpClientTest do
                )
              )
     end
+
+    test "returns explicit error when authentication fails" do
+      expected_response = %{body: %{"error" => "Bad credentials"}, status_code: 401}
+
+      assert HttpClient.post("/sample-endpoint", sample_request_body(), config(@bad_credentials)) ==
+               expected_response
+    end
   end
 
   #####################
   # Private functions #
   #####################
 
-  defp sample_credentials do
-    %Credentials{
-      client_id: "sample-client-id",
-      client_secret: "sample-client-secret"
-    }
+  defp authenticator_response(@good_credentials) do
+    {:ok, "sample-access-token"}
+  end
+
+  defp authenticator_response(@bad_credentials) do
+    {:error, %OAuth2.Response{status_code: 401, body: %{"error" => "Bad credentials"}}}
   end
 
   defp sample_request_body, do: Jason.encode!(%{sample: "request"})
@@ -82,9 +106,9 @@ defmodule StuartClientElixirTest.HttpClientTest do
       "Content-Type": "application/json"
     ]
 
-  defp config,
+  defp config(credentials \\ @good_credentials),
     do: %{
       environment: Environment.sandbox(),
-      credentials: sample_credentials()
+      credentials: credentials
     }
 end


### PR DESCRIPTION
In https://github.com/StuartApp/stuart-client-elixir/pull/9 we added authentication errors handling.

This PR improves by responding with a similar format using as well `to_api_response()`.