### PR TITLE
Authenticator.forget_token!/1

### DIFF
--- a/lib/stuart_client_elixir.ex
+++ b/lib/stuart_client_elixir.ex
@@ -1,6 +1,7 @@
 defmodule StuartClientElixir do
-  alias StuartClientElixir.HttpClient
+  alias StuartClientElixir.{HttpClient, Authenticator}
 
   defdelegate get(resource, options), to: HttpClient
   defdelegate post(resource, body, options), to: HttpClient
+  defdelegate forget_token!(client_id), to: Authenticator
 end

--- a/lib/stuart_client_elixir/authenticator.ex
+++ b/lib/stuart_client_elixir/authenticator.ex
@@ -17,6 +17,10 @@ defmodule StuartClientElixir.Authenticator do
     end
   end
 
+  def forget_token!(client_id) do
+    remove_from_cache(client_id)
+  end
+
   #####################
   # Private functions #
   #####################
@@ -62,5 +66,9 @@ defmodule StuartClientElixir.Authenticator do
     {:ok, true} = Cachex.put(:stuart_oauth_tokens, client_id, oauth2_token)
 
     {:ok, oauth2_token}
+  end
+
+  defp remove_from_cache(client_id) do
+    {:ok, _} = Cachex.del(:stuart_oauth_tokens, client_id)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule StuartClientElixir.MixProject do
       {:httpoison, "~> 1.3.1"},
       {:oauth2, "~> 0.9.3"},
       {:jason, "~> 1.1.1"},
-      {:cachex, "~> 3.0.3"},
+      {:cachex, "~> 3.1"},
       {:mox, "~> 0.4.0", only: :test},
       {:mock, "~> 0.3.2", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,12 @@
 %{
-  "cachex": {:hex, :cachex, "3.0.3", "4e2d3e05814a5738f5ff3903151d5c25636d72a3527251b753f501ad9c657967", [:mix], [{:eternal, "~> 1.2", [hex: :eternal, repo: "hexpm", optional: false]}, {:unsafe, "~> 1.0", [hex: :unsafe, repo: "hexpm", optional: false]}], "hexpm"},
+  "cachex": {:hex, :cachex, "3.1.1", "588bcf48d20eddad7bff5172f5453090a071eba3191a03f51f779f88e3ac1900", [:mix], [{:eternal, "~> 1.2", [hex: :eternal, repo: "hexpm", optional: false]}, {:jumper, "~> 1.0", [hex: :jumper, repo: "hexpm", optional: false]}, {:unsafe, "~> 1.0", [hex: :unsafe, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "eternal": {:hex, :eternal, "1.2.0", "e2a6b6ce3b8c248f7dc31451aefca57e3bdf0e48d73ae5043229380a67614c41", [:mix], [], "hexpm"},
+  "eternal": {:hex, :eternal, "1.2.1", "d5b6b2499ba876c57be2581b5b999ee9bdf861c647401066d3eeed111d096bc4", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.3.1", "7ac607311f5f706b44e8b3fab736d0737f2f62a31910ccd9afe7227b43edb7f0", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "jumper": {:hex, :jumper, "1.0.1", "3c00542ef1a83532b72269fab9f0f0c82bf23a35e27d278bfd9ed0865cecabff", [:mix], [], "hexpm"},
   "meck": {:hex, :meck, "0.8.12", "1f7b1a9f5d12c511848fec26bbefd09a21e1432eadb8982d9a8aceb9891a3cf2", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
@@ -15,5 +16,5 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "unsafe": {:hex, :unsafe, "1.0.0", "7c21742cd05380c7875546b023481d3a26f52df8e5dfedcb9f958f322baae305", [:mix], [], "hexpm"},
+  "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm"},
 }

--- a/test/stuart_client_elixir/authenticator_test.exs
+++ b/test/stuart_client_elixir/authenticator_test.exs
@@ -88,6 +88,27 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
     end
   end
 
+  describe "forget_token!" do
+    test "deletes the cached token for the given client_id" do
+      Cachex.put(
+        :stuart_oauth_tokens,
+        "client-id",
+        sample_token(
+          access_token: "sample-cached-token",
+          expires_at: System.system_time(:second) + 60 * 60
+        )
+      )
+
+      assert {:ok, "sample-cached-token"} ==
+               Authenticator.access_token(Environment.sandbox(), good_credentials())
+
+      assert {:ok, true} == Authenticator.forget_token!("client-id")
+
+      assert {:ok, "sample-new-token"} ==
+               Authenticator.access_token(Environment.sandbox(), good_credentials())
+    end
+  end
+
   #####################
   # Private functions #
   #####################


### PR DESCRIPTION
This PR adds a `forget_token!` function to force the deletion of a cached token, given its `client_id`.

This can be needed for example when you have an application that uses a pair of `client_id` and `client_secret`, and a valid cached token for those credentials - if later the `client_secret` has been changed, you may want to get a fresh token but it won't as there is already a cached one for the unchanged `client_id`.

In this case, you could run `StuartClientElixir.forget_token!(client_id)` to get rid of the cached token.

