### PR TITLE
Handles OAuth2.Error

### DIFF
--- a/lib/stuart_client_elixir/authenticator.ex
+++ b/lib/stuart_client_elixir/authenticator.ex
@@ -33,6 +33,7 @@ defmodule StuartClientElixir.Authenticator do
       {:ok, access_token}
     else
       {:error, %OAuth2.Response{} = oauth_response} -> {:error, oauth_response}
+      {:error, %OAuth2.Error{} = oauth_error} -> {:error, oauth_error}
     end
   end
 

--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -17,7 +17,8 @@ defmodule StuartClientElixir.HttpClient do
       HTTPoison.get(url, headers, default_options())
       |> to_api_response()
     else
-      {:error, %OAuth2.Response{}} = oauth_error -> to_api_response(oauth_error)
+      {:error, %OAuth2.Response{}} = oauth_response -> to_api_response(oauth_response)
+      {:error, %OAuth2.Error{}} = oauth_error -> to_api_response(oauth_error)
     end
   end
 
@@ -28,7 +29,8 @@ defmodule StuartClientElixir.HttpClient do
       HTTPoison.post(url, body, headers, default_options())
       |> to_api_response()
     else
-      {:error, %OAuth2.Response{}} = oauth_error -> to_api_response(oauth_error)
+      {:error, %OAuth2.Response{}} = oauth_response -> to_api_response(oauth_response)
+      {:error, %OAuth2.Error{}} = oauth_error -> to_api_response(oauth_error)
     end
   end
 
@@ -54,11 +56,11 @@ defmodule StuartClientElixir.HttpClient do
     %{status_code: status_code, body: Jason.decode!(body)}
   end
 
-  defp to_api_response({:error, %HTTPoison.Error{} = error}) do
-    {:error, error}
-  end
-
   defp to_api_response({:error, %OAuth2.Response{status_code: status_code, body: body}}) do
     %{status_code: status_code, body: body}
+  end
+
+  defp to_api_response({:error, error}) do
+    {:error, error}
   end
 end

--- a/test/stuart_client_elixir/authenticator_test.exs
+++ b/test/stuart_client_elixir/authenticator_test.exs
@@ -43,6 +43,17 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
                 }}
     end
 
+    test "returns an error for OAuth2.Error" do
+      assert Authenticator.access_token(Environment.sandbox(), error_credentials()) ==
+               {:error,
+                %OAuth2.Error{
+                  reason:
+                    {:options,
+                     {:socket_options,
+                      [packet_size: 0, packet: 0, header: 0, active: false, mode: :binary]}}
+                }}
+    end
+
     test "returns a new access token when no access token exists" do
       # when
       {:ok, access_token} = Authenticator.access_token(Environment.sandbox(), good_credentials())
@@ -121,6 +132,10 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
     %Credentials{client_id: "client-id", client_secret: "bad"}
   end
 
+  defp error_credentials do
+    %Credentials{client_id: "client-id", client_secret: "error"}
+  end
+
   defp sample_client(
          strategy: OAuth2.Strategy.ClientCredentials,
          client_id: client_id,
@@ -161,6 +176,15 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
        },
        headers: [],
        status_code: 401
+     }}
+  end
+
+  defp get_token_response(%OAuth2.Client{client_secret: "error"}) do
+    {:error,
+     %OAuth2.Error{
+       reason:
+         {:options,
+          {:socket_options, [packet_size: 0, packet: 0, header: 0, active: false, mode: :binary]}}
      }}
   end
 


### PR DESCRIPTION
The OAuth library can return also this, and not only an OAuth2.Response:

https://hexdocs.pm/oauth2/0.9.4/OAuth2.Client.html#get_token/4

This patch adds handling for both cases of error result.