### PR TITLE
Removes obsolete instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ For a complete documentation of all endpoints offered by the Stuart API, you can
 ```elixir
 # mix.exs
 
-def application do
-  [applications: [:stuart_client_elixir]]
-end
-
 def deps do
   [
     {:stuart_client_elixir, "~> 1.2.0"}


### PR DESCRIPTION
Mix infers the list of OTP applications the project depends on [since version 1.4](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference).