### PR TITLE
handle 204 No Content response

### DIFF
--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -66,6 +66,10 @@ defmodule StuartClientElixir.HttpClient do
     ]
   end
 
+  defp to_api_response({:ok, %HTTPoison.Response{status_code: 204}}) do
+    %{status_code: 204, body: ""}
+  end
+
   defp to_api_response({:ok, %HTTPoison.Response{status_code: status_code, body: body}}) do
     %{status_code: status_code, body: Jason.decode!(body)}
   end

--- a/test/stuart_client_elixir/http_client_test.exs
+++ b/test/stuart_client_elixir/http_client_test.exs
@@ -150,14 +150,37 @@ defmodule StuartClientElixirTest.HttpClientTest do
     end
   end
 
+  describe "handles 204 no content response" do
+    @expected_no_content_response %{status_code: 204, body: ""}
+
+    test "204 no content in GET" do
+      assert HttpClient.get("/no_content", config()) == @expected_no_content_response
+    end
+
+    test "204 no content in POST" do
+      assert HttpClient.post("/no_content", sample_request_body(), config()) ==
+               @expected_no_content_response
+    end
+
+    test "204 no content in PATCH" do
+      assert HttpClient.patch("/no_content", sample_request_body(), config()) ==
+               @expected_no_content_response
+    end
+  end
+
   #####################
   # Private functions #
   #####################
 
   @timeout_url "https://sandbox-api.stuart.com/timeout"
+  @no_content_url "https://sandbox-api.stuart.com/no_content"
 
   defp response(_, @timeout_url) do
     {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
+  end
+
+  defp response(_, @no_content_url) do
+    {:ok, %HTTPoison.Response{status_code: 204, body: ""}}
   end
 
   defp response(:get, _) do


### PR DESCRIPTION
This PR adds support for handling 204 No Content responses, such as in cancellation requests.

For these cases we don't want to attempt to decode the response body as JSON as it will be empty, so we can directly return a 204 status code and a blank body.