### PR TITLE
Handling invalid json errors

### DIFF
--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -73,9 +73,6 @@ defmodule StuartClientElixir.HttpClient do
   defp to_api_response({:ok, %HTTPoison.Response{status_code: status_code, body: body}}) do
     with {:ok, decoded_body} <- Jason.decode(body) do
       %{status_code: status_code, body: decoded_body}
-    else
-      error ->
-        error
     end
   end
 

--- a/lib/stuart_client_elixir/http_client.ex
+++ b/lib/stuart_client_elixir/http_client.ex
@@ -71,7 +71,12 @@ defmodule StuartClientElixir.HttpClient do
   end
 
   defp to_api_response({:ok, %HTTPoison.Response{status_code: status_code, body: body}}) do
-    %{status_code: status_code, body: Jason.decode!(body)}
+    with {:ok, decoded_body} <- Jason.decode(body) do
+      %{status_code: status_code, body: decoded_body}
+    else
+      error ->
+        error
+    end
   end
 
   defp to_api_response({:error, %OAuth2.Response{status_code: status_code, body: body}}) do

--- a/test/stuart_client_elixir/http_client_test.exs
+++ b/test/stuart_client_elixir/http_client_test.exs
@@ -168,12 +168,29 @@ defmodule StuartClientElixirTest.HttpClientTest do
     end
   end
 
+  describe "handles invalid json response" do
+    @expected_invalid_json_response {:error, %Jason.DecodeError{data: "", position: 0, token: nil}}
+
+    test "invalid json in GET" do
+      assert HttpClient.get("/invalid_json", config()) == @expected_invalid_json_response
+    end
+
+    test "invalid json in POST" do
+      assert HttpClient.post("/invalid_json", sample_request_body(), config()) == @expected_invalid_json_response
+    end
+
+    test "invalid json in PATCH" do
+      assert HttpClient.patch("/invalid_json", sample_request_body(), config()) == @expected_invalid_json_response
+    end
+  end
+
   #####################
   # Private functions #
   #####################
 
   @timeout_url "https://sandbox-api.stuart.com/timeout"
   @no_content_url "https://sandbox-api.stuart.com/no_content"
+  @invalid_json_url "https://sandbox-api.stuart.com/invalid_json"
 
   defp response(_, @timeout_url) do
     {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
@@ -181,6 +198,10 @@ defmodule StuartClientElixirTest.HttpClientTest do
 
   defp response(_, @no_content_url) do
     {:ok, %HTTPoison.Response{status_code: 204, body: ""}}
+  end
+
+  defp response(_, @invalid_json_url) do
+    {:ok, %HTTPoison.Response{status_code: 500, body: ""}}
   end
 
   defp response(:get, _) do

--- a/test/stuart_client_elixir/http_client_test.exs
+++ b/test/stuart_client_elixir/http_client_test.exs
@@ -169,18 +169,21 @@ defmodule StuartClientElixirTest.HttpClientTest do
   end
 
   describe "handles invalid json response" do
-    @expected_invalid_json_response {:error, %Jason.DecodeError{data: "", position: 0, token: nil}}
+    @expected_invalid_json_response {:error,
+                                     %Jason.DecodeError{data: "", position: 0, token: nil}}
 
     test "invalid json in GET" do
       assert HttpClient.get("/invalid_json", config()) == @expected_invalid_json_response
     end
 
     test "invalid json in POST" do
-      assert HttpClient.post("/invalid_json", sample_request_body(), config()) == @expected_invalid_json_response
+      assert HttpClient.post("/invalid_json", sample_request_body(), config()) ==
+               @expected_invalid_json_response
     end
 
     test "invalid json in PATCH" do
-      assert HttpClient.patch("/invalid_json", sample_request_body(), config()) == @expected_invalid_json_response
+      assert HttpClient.patch("/invalid_json", sample_request_body(), config()) ==
+               @expected_invalid_json_response
     end
   end
 


### PR DESCRIPTION
https://stuart-team.atlassian.net/browse/INT-9

We've identified that when making http request calls and there is a 500 error for instance the function `to_api_response` always tries to parse the json which ends up raising an `Jason.DecodeError` exception.

With this change we return the tuple error instead. We will adapt monocle code afterwards to adapt it to this change.

