### PR TITLE
Fix oauth new behavior after upgrading to v2

### DIFF
--- a/lib/stuart_client_elixir/authenticator.ex
+++ b/lib/stuart_client_elixir/authenticator.ex
@@ -48,6 +48,7 @@ defmodule StuartClientElixir.Authenticator do
       client_secret: client_secret,
       site: site
     )
+    |> OAuth2.Client.put_serializer("application/json", Jason)
   end
 
   defp cache_exists?(%Credentials{client_id: client_id}),

--- a/test/stuart_client_elixir/authenticator_test.exs
+++ b/test/stuart_client_elixir/authenticator_test.exs
@@ -19,6 +19,9 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
         new: fn oauth_params ->
           sample_client(oauth_params)
         end,
+        put_serializer: fn oauth_client, content_type, serializer ->
+          client_with_serializer(oauth_client, content_type, serializer)
+        end,
         get_token: fn oauth_client ->
           get_token_response(oauth_client)
         end
@@ -156,6 +159,10 @@ defmodule StuartClientElixirTest.AuthenticatorTest do
       token_method: :post,
       token_url: "/oauth/token"
     }
+  end
+
+  defp client_with_serializer(oauth_client, content_type, serializer) do
+    %{oauth_client | serializers: %{content_type => serializer}}
   end
 
   defp get_token_response(%OAuth2.Client{client_secret: "client-secret"}) do


### PR DESCRIPTION
After including latest changes in a new monocle branch some e2e tests were broken when accessing stuart-api. Part of those changes were upgrading oauth version from 0.9 to 2.0. When reading the changelog we realized "application/json" serializing wasn't the default anymore so after the upgrade the token was being stored as the full json string.

With this change we explicitly set "application/json" as the content type and Jason as the serializer.

Edit: https://github.com/scrogson/oauth2/blob/master/CHANGELOG.md#v100-2019-03-13